### PR TITLE
fix broken links

### DIFF
--- a/app/(wiki)/(articles)/obstacles/articles/gold_rock.mdx
+++ b/app/(wiki)/(articles)/obstacles/articles/gold_rock.mdx
@@ -1,4 +1,4 @@
-The **Gold Rock** is a very rare variant of the [Rock](/obstacles/rock), and was added in the v0.5.0 "Locked & Loaded" update on June 24th, 2023. It has 25% more health than a normal Rock and drops a [Mosin-Nagant](/weapons/guns/mosin_nagant).
+The **Gold Rock** is a very rare variant of the [Rock](/obstacles/rock), and was added in the v0.5.0 "Locked & Loaded" update on June 24th, 2023. It has 25% more health than a normal Rock and drops a [Mosin-Nagant](/weapons/guns/mosin).
 
 # Location & Spawning
 Only one Gold Rock spawns per map.
@@ -13,7 +13,7 @@ The Gold Rock has a [100% chance](/loot#gold_rock) of dropping a Mosin-Nagant.
 - Unless you have a LMG, it's likely not worth it to try and destroy the Gold Rock if a player is hiding behind it, due to the large amount of health it has.
 
 # Trivia
-- Prior to v0.11.0, the only way to get a [Tango 51](weapons/guns/tango_51) was from the Gold Rock
+- Prior to v0.11.0, the only way to get a [Tango 51](/weapons/guns/tango_51) was from the Gold Rock
     - The chance for a Mosin-Nagant was 90.9% (1/1.1) and the chance for a Tango 51 was 9.1% (0.1/1.1)
 - The Gold Rock was designed by Katloo
 


### PR DESCRIPTION
mosin nagant article is called mosin, not mosin-nagant 
missing forward slash in link for tango