### PR TITLE
Add a table of drop rates for every item

### DIFF
--- a/app/(wiki)/equipment/armor/articles/basic_helmet.md
+++ b/app/(wiki)/equipment/armor/articles/basic_helmet.md
@@ -4,6 +4,8 @@ The **Basic Helmet** is a piece of [Equipment](/equipment) added in the v0.7.0 "
 
 The Basic Helmet is easily obtained from common loot sources such as normal, AEGIS, or flint [crates](/obstacles/crates). 
 
+<Obtaining item="basic_helmet" />
+
 # Trivia
 
 - The Basic Helmet was designed by Slapdap

--- a/app/(wiki)/equipment/armor/articles/basic_vest.md
+++ b/app/(wiki)/equipment/armor/articles/basic_vest.md
@@ -4,6 +4,8 @@ The **Basic Vest** is a piece of [Equipment](/equipment) added in the v0.7.0 "Ge
 
 The Basic Vest is easily obtained from common loot sources such as normal, AEGIS, or flint [crates](/obstacles/crates). 
 
+<Obtaining item="basic_vest" />
+
 # Trivia
 
 - The Basic Vest was designed by Slapdap

--- a/app/(wiki)/equipment/armor/articles/regular_helmet.md
+++ b/app/(wiki)/equipment/armor/articles/regular_helmet.md
@@ -3,7 +3,9 @@ The **Regular Helmet** is a piece of [Equipment](/equipment) added in the v0.7.0
 # Obtaining
 
 The Regular Helmet can be obtained from common loot sources such as normal, AEGIS, or flint [crates](/obstacles/crates). 
-However, it is rarer when compared to the Regular Helmet.
+However, it is rarer when compared to the Basic Helmet.
+
+<Obtaining item="regular_helmet" />
 
 # Trivia
 

--- a/app/(wiki)/equipment/armor/articles/regular_vest.md
+++ b/app/(wiki)/equipment/armor/articles/regular_vest.md
@@ -3,7 +3,9 @@ The **Regular Vest** is a piece of [Equipment](/equipment) added in the v0.7.0 "
 # Obtaining
 
 The Regular Vest can be obtained from common loot sources such as normal, AEGIS, or flint [crates](/obstacles/crates). 
-However, it is rarer when compared to the Regular Vest.
+However, it is rarer when compared to the Basic Vest.
+
+<Obtaining item="regular_vest" />
 
 # Trivia
 

--- a/app/(wiki)/equipment/armor/articles/tactical_helmet.md
+++ b/app/(wiki)/equipment/armor/articles/tactical_helmet.md
@@ -4,6 +4,8 @@ The **Tactical Helmet** is a piece of [Equipment](/equipment) added in the v0.7.
 
 The Tactical Helmet can be obtained rarely from common loot sources such as [crates](/obstacles/crates), but it is most easily found from an [Airdrop](/obstacles/airdrops) because they have a guranteed chance to drop one piece of level 3 equipment. 
 
+<Obtaining item="tactical_helmet" />
+
 # Trivia 
 
  - The Tactical Helmet was designed by Slapdap

--- a/app/(wiki)/equipment/armor/articles/tactical_vest.md
+++ b/app/(wiki)/equipment/armor/articles/tactical_vest.md
@@ -4,6 +4,8 @@ The **Tactical Vest** is a piece of [Equipment](/equipment) added in the v0.7.0 
 
 The Tactical Vest can be obtained rarely from common loot sources such as [crates](/obstacles/crates), but it is most easily found from an [Airdrop](/obstacles/airdrops) because they have a guranteed chance to drop one piece of level 3 equipment. 
 
+<Obtaining item="tactical_vest" />
+
 # Trivia 
 
  - The Tactical Vest was designed by Slapdap and jc

--- a/app/(wiki)/equipment/backpacks/articles/basic_pack.md
+++ b/app/(wiki)/equipment/backpacks/articles/basic_pack.md
@@ -4,6 +4,8 @@ The **Basic Pack** is a piece of [Equipment](/equipment) added in the v0.7.0 "Ge
 
 The Basic Pack is easily obtained from common loot sources such as normal, AEGIS, or flint [crates](/obstacles/crates). 
 
+<Obtaining item="basic_pack" />
+
 # Trivia 
 
 - The Basic Pack was designed by Slapdap

--- a/app/(wiki)/equipment/backpacks/articles/regular_pack.md
+++ b/app/(wiki)/equipment/backpacks/articles/regular_pack.md
@@ -4,6 +4,8 @@ The **Regular Pack** is a piece of [Equipment](/equipment) added in the v0.7.0 "
  
 The Regular Pack can be obtained from common loot sources such as normal, AEGIS, or flint [crates](/obstacles/crates). However, it is rarer when compared to the Basic Pack.
 
+<Obtaining item="regular_pack" />
+
 # Trivia 
 
  - The Regular Pack was designed by Slapdap

--- a/app/(wiki)/equipment/backpacks/articles/tactical_pack.md
+++ b/app/(wiki)/equipment/backpacks/articles/tactical_pack.md
@@ -4,6 +4,8 @@ The **Tactical Pack** is a piece of [Equipment](/equipment) added in the v0.7.0 
 
 The Tactical Pack can be obtained rarely from common loot sources such as [crates](/obstacles/crates), but it is most easily found from an [Airdrop](/obstacles/airdrops) because they have a guaranteed chance to drop one piece of level 3 equipment. 
 
+<Obtaining item="tactical_pack" />
+
 # Trivia 
 
  - The Tactical Pack was designed by Slapdap

--- a/app/(wiki)/healing/articles/cola.md
+++ b/app/(wiki)/healing/articles/cola.md
@@ -25,6 +25,8 @@ Cola is a type of carbonated drink typically flavored with citrus oils, vanilla,
 
 Cola is most readily obtained by breaking toilets in buildings, as well as the Porta-Potty. However, the best way to get Cola is to break the fridge, which always drops 2-3 Cola. Cola can also be found in crates and even world loot.
 
+<Obtaining item="cola" />
+
 # Trivia
 
 - The caffeine in Colas may help the Surian run faster and regenerate health

--- a/app/(wiki)/healing/articles/gauze.md
+++ b/app/(wiki)/healing/articles/gauze.md
@@ -23,6 +23,8 @@ Gauze intended for use as a medical item is typically made of cotton. It is usef
 
 Gauze is a very common drop from crates, toilets, and the toilet in a Porta Potty. It can also be readily found as ground loot.
 
+<Obtaining item="gauze" />
+
 # Trivia
 
 - Before Gauze and other consumables were added, the only way to heal yourself was to break a Health Crate

--- a/app/(wiki)/healing/articles/medikit.md
+++ b/app/(wiki)/healing/articles/medikit.md
@@ -27,6 +27,8 @@ Medical kits, also known as first aid kits, contain a variety of different suppl
 
 Medikits are most commonly found in Toilets and the Porta-Potty. They can also be found rarely in crates or as ground loot.
 
+<Obtaining item="medikit" />
+
 # Trivia
 
 - Before Medikits and other consumables were added, the only way to heal yourself was to break a Health Crate

--- a/app/(wiki)/healing/articles/tablets.md
+++ b/app/(wiki)/healing/articles/tablets.md
@@ -25,6 +25,8 @@ Tablets, also known as pills, are a solid form of oral medicine. They usually in
 
 Tablets are most readily obtained by breaking toilets in buildings, as well as the Porta-Potty. Tablets can also be rarely found in crates and even world loot.
 
+<Obtaining item="tablets" />
+
 # Trivia
 
 - Presumably, the Tablets are some kind of painkiller

--- a/app/(wiki)/weapons/guns/articles/acr.md
+++ b/app/(wiki)/weapons/guns/articles/acr.md
@@ -23,7 +23,9 @@ The ACR was designed by Magpul Industries in the early 2000s and was essentially
 
 # Obtaining
 
-- The only way to get the ACR is to either find one in a [Gold Airdrop](/obstacles/gold_airdrop_crate) or by breaking a [Flint Stone](/obstacles/flint_stone).
+The only way to get the ACR is to either find one in a [Gold Airdrop](/obstacles/gold_airdrop_crate) or by breaking a [Flint Stone](/obstacles/flint_stone).
+
+<Obtaining item="acr" />
 
 # Trivia
 

--- a/app/(wiki)/weapons/guns/articles/ak47.md
+++ b/app/(wiki)/weapons/guns/articles/ak47.md
@@ -27,6 +27,7 @@ The AK-47 was developed by Mikhail Kalashnikov between 1945 and 1947. Accepted i
 # Obtaining
 
 The AK-47 is one of the more common guns in the game. It is less common than pistols and SMGs but can be found in a variety of places.
+<Obtaining item='ak47' />
 
 # Trivia
 

--- a/app/(wiki)/weapons/guns/articles/ak47.md
+++ b/app/(wiki)/weapons/guns/articles/ak47.md
@@ -27,7 +27,8 @@ The AK-47 was developed by Mikhail Kalashnikov between 1945 and 1947. Accepted i
 # Obtaining
 
 The AK-47 is one of the more common guns in the game. It is less common than pistols and SMGs but can be found in a variety of places.
-<Obtaining item='ak47' />
+
+<Obtaining item="ak47" />
 
 # Trivia
 

--- a/app/(wiki)/weapons/guns/articles/arx160.md
+++ b/app/(wiki)/weapons/guns/articles/arx160.md
@@ -23,6 +23,8 @@ The ARX160 was developed for the Italian Armed Forces in 2008. It is available i
 
 The ARX-160 is relatively common in higher-tier crates such as the A.E.G.I.S. crate. It can also be found uncommonly as world loot.
 
+<Obtaining item="arx160" />
+
 # Trivia
 
 - In real life, the ARX160 can be converted to 7.62x39mm using a conversion kit

--- a/app/(wiki)/weapons/guns/articles/aug.md
+++ b/app/(wiki)/weapons/guns/articles/aug.md
@@ -24,6 +24,8 @@ The AUG was designed by Steyr Arms in 1977 entering service in the same year. Si
 
 The AUG is a very common gun, being more common than the [AK-47](weapons/guns/ak47). It can be found in many Crates such as the [Regular Crate](/obstacles/regular_crate) and [Flint](/obstacles/flint_crate)/[AEGIS Crates](/obstacles/aegis_crate), as well as ground loot.
 
+<Obtaining item="aug" />
+
 # History
 
 - v0.13.0

--- a/app/(wiki)/weapons/guns/articles/barrett.md
+++ b/app/(wiki)/weapons/guns/articles/barrett.md
@@ -40,6 +40,8 @@ The Barrett M95 is a redesigned version of the Barrett M90, which was itself a b
 
 - The only way to get the Barrett is to either find one in a [Gold Airdrop](/obstacles/gold_airdrop_crate) or by breaking a [Flint Stone](/obstacles/flint_stone).
 
+<Obtaining item="barrett" />
+
 # Trivia
 
 - The Barrett is the second bullpup weapon to be added to Suroi, after the [AUG](/weapons/guns/aug)

--- a/app/(wiki)/weapons/guns/articles/cz75a.md
+++ b/app/(wiki)/weapons/guns/articles/cz75a.md
@@ -27,6 +27,8 @@ The CZ 75 was designed by František Koucký starting in 1969. It uses a recoil 
 
 - The CZ-75A is one of the most common weapons in the game. It can be readily found as ground loot or in Crates (most commonly the [Regular Crate](/obstacles/regular_crate)).
 
+<Obtaining item="cz75a" />
+
 # Trivia
 
 - Before 0.9.0, the [G19](/weapons/guns/g19) was fully automatic. After the CZ-75A was added, it was switched to semi-automatic

--- a/app/(wiki)/weapons/guns/articles/flues.md
+++ b/app/(wiki)/weapons/guns/articles/flues.md
@@ -23,9 +23,11 @@ The Flues gets its name from designer Emil Flues, who worked for the Ithaca Gun 
 - Depending on the opponent's skill, they may miss one or both of their shots. Strafe them and try and make them miss, then attack while they reload.
 - Be wary of Bushes and entrances to Buildings if you suspect someone is camping.
 
-# Rarity
+# Obtaining
 
 The Flues is currently the second-rarest shotgun in the game. It is about 5 times as rare as the [M3K](/weapons/guns/m3k) and the same level rarity as the [ARX-160](/weapons/guns/arx160) in normal mode.
+
+<Obtaining item="flues" />
 
 # Trivia
 

--- a/app/(wiki)/weapons/guns/articles/g19.md
+++ b/app/(wiki)/weapons/guns/articles/g19.md
@@ -24,6 +24,8 @@ The Glock 19 is a "Compact" version of the Glock 17. It carries fifteen rounds i
 
 The G19 is a very common weapon that can be found almost anywhere. It usually spawns from low-tier loot sources such as [Regular Crates](/obstacles/regular_crate).
 
+<Obtaining item="g19" />
+
 # Trivia
 
 - The G19 is named "G19" instead of "Glock 19" due to copyright concerns

--- a/app/(wiki)/weapons/guns/articles/hp18.md
+++ b/app/(wiki)/weapons/guns/articles/hp18.md
@@ -29,6 +29,8 @@ The HP-18 is a cheaper entry-level shotgun offered by Iver Johnson Arms. It has 
 
 The HP18 is the most common shotgun available on the normal map. It can be found as ground loot, in different Crates, and many other places.
 
+<Obtaining item="hp18" />
+
 # Trivia
 
 - The HP18 replaced the now-removed [940 Pro](/weapons/guns/940pro) in update v0.7.0

--- a/app/(wiki)/weapons/guns/articles/lewis_gun.md
+++ b/app/(wiki)/weapons/guns/articles/lewis_gun.md
@@ -29,6 +29,8 @@ The Lewis gun was invented in 1911 by Isaac Newton Lewis, a U.S. Army colonel. I
 
 The Lewis Gun can be rarely found as world loot, but it is more common in higher-tier places such as [Flint](/obstacles/flint_crate) and [AEGIS Crates](/obstacles/aegis_crate).
 
+<Obtaining item="lewis_gun" />
+
 # Trivia
 
 - Most Lewis Guns in real life were chambered for .303 British or .30-06 Springfield

--- a/app/(wiki)/weapons/guns/articles/m16a4.md
+++ b/app/(wiki)/weapons/guns/articles/m16a4.md
@@ -23,6 +23,8 @@ The M16 series of rifles is based off of the larger AR-10 series of rifles, both
 
 - The M16 is a rare weapon, being as rare as the [ARX-160](/weapons/guns/arx160), [MCX Spear](/weapons/guns/mcx_spear) and the [Flues](/weapons/guns/flues). Thus, it is best obtained from rare loot sources like [Flint](/obstacles/flint_crate) or [AEGIS Crates](/obstacles/aegis_crate).
 
+<Obtaining item="m16a4" />
+
 # Trivia
 
 - There are currently 8 million M16s in the world

--- a/app/(wiki)/weapons/guns/articles/m1895.md
+++ b/app/(wiki)/weapons/guns/articles/m1895.md
@@ -27,6 +27,8 @@ The M1895 was designed by the Belgian Léon Nagant for the Russian Empire. It is
 
 The M8195 is one of the most common weapons guns in the game and can be found in many places around the map.
 
+<Obtaining item="m8195" />
+
 # Trivia
 
 - Initially, the M1895 would eject casings after each shot. Being a revolver, this is not possible in real life

--- a/app/(wiki)/weapons/guns/articles/m1_garand.md
+++ b/app/(wiki)/weapons/guns/articles/m1_garand.md
@@ -29,6 +29,8 @@ The M1 Garand was designed by John Garand in the 1920s and 1930s, and production
 
 - The only way to get the M1 Garand is to either find one in a [Gold Airdrop](/obstacles/gold_airdrop_crate) or by breaking a [Flint Stone](/obstacles/flint_stone).
 
+<Obtaining item="m1_garand" />
+
 # Trivia
 
 - The "ping" sound after the last round is the sound of the en bloc clip being ejected

--- a/app/(wiki)/weapons/guns/articles/m3k.md
+++ b/app/(wiki)/weapons/guns/articles/m3k.md
@@ -25,6 +25,8 @@ The M3K is an affordable budget semi-automatic shotgun offered by Stoeger Indust
 
 The M3K is uncommon in general world loot, but fairly common in rarer loot sources such as [AEGIS Crates](/obstacles/aegis_crate).
 
+<Obtaining item="m3k" />
+
 # Trivia
 
 - The M3K was one of the first guns to be added to the game, alongside the [AK-47](/weapons/guns/ak47)

--- a/app/(wiki)/weapons/guns/articles/mcx_spear.md
+++ b/app/(wiki)/weapons/guns/articles/mcx_spear.md
@@ -28,7 +28,9 @@ The MCX Spear is the civilian version of the XM7, which was selected by the US m
 
 The MCX Spear is found rarely as world loot in locations such as [Regular Crates](/obstacles/regular_crate). It is a more common drop from special locations such as [AEGIS](/obstacles/aegis_crate) and [Flint Crate](/obstacles/flint_crate).
 
-- The MCX Spear has a 99% chance to be found in the Office at the [Refinery](/buildings/refinery).
+- A MCX Spear mount has a 99% chance to be found in the Office at the [Refinery](/buildings/refinery), with the other 1% being a [Stoner 63](/weapons/guns/stoner_63).
+
+<Obtaining item="mcx_spear" />
 
 # Trivia
 

--- a/app/(wiki)/weapons/guns/articles/micro_uzi.md
+++ b/app/(wiki)/weapons/guns/articles/micro_uzi.md
@@ -29,6 +29,8 @@ The original Uzi is an open-bolt, blowback-operated design, very similar to the 
 
 The Micro Uzi is a very common gun, and can be found from [Regular Crates](/obstacles/regular_crate), as ground loot, and readily found from [AEGIS](/obstacles/aegis_crate) and [Flint Crates](/obstacles/flint_crate).
 
+<Obtaining item="micro_uzi" />
+
 # Trivia
 
 - The Micro Uzi was the second SMG to be added to the game, after the [SAF-200](weapons/guns/saf200)

--- a/app/(wiki)/weapons/guns/articles/mini14.md
+++ b/app/(wiki)/weapons/guns/articles/mini14.md
@@ -27,6 +27,8 @@ The Mini-14, as the name suggests, is based on the bigger 7.62x51mm NATO firing 
 
 The Mini-14 can be found rarely as world loot but is more common in rare drops such as from [AEGIS](/obstacles/aegis_crate) and [Flint Crates](/obstacles/flint_crate), [Airdrops](/obstacles/airdrop_crate), or from the center of a [Warehouse](/buildings/warehouse).
 
+<Obtaining item="mini14" />
+
 # Trivia
 
 - The reference image for the Mini-14 is one of the developer's own Mini-14

--- a/app/(wiki)/weapons/guns/articles/model_37.md
+++ b/app/(wiki)/weapons/guns/articles/model_37.md
@@ -24,6 +24,8 @@ After the shotgun was proven an effective weapon in WW1, demand for them skyrock
 
 The Model 37 is fairly common as both ground loot as well as in places such as [Regular Crates](/obstacles/regular_crate).
 
+<Obtaining item="model37" />
+
 # Trivia
 
 - The reference image for the in-game Model 37 is based on a "Trench" variant of the Model 37, complete with a bayonet mount

--- a/app/(wiki)/weapons/guns/articles/mosin.md
+++ b/app/(wiki)/weapons/guns/articles/mosin.md
@@ -32,6 +32,8 @@ The Mosin-Nagant was designed in 1891 by Captain Sergei Mosin and Émile Nagant 
 
 The Mosin-Nagant is an uncommon drop from higher-tier crates such as the [AEGIS Crate](/obstacles/aegis_crate) and [Airdrops](/obstacles/airdrop_crate). It can also be found rarely as world loot. It has a guaranteed drop chance from the [Gold Rock](/obstacles/gold_rock), which always spawns once per map.
 
+<Obtaining item="mosin" />
+
 # Trivia
 
 - Émile Nagant's brother, Léon Nagant, designed the [M1895](/weapons/guns/m1895) revolver

--- a/app/(wiki)/weapons/guns/articles/mp40.md
+++ b/app/(wiki)/weapons/guns/articles/mp40.md
@@ -27,6 +27,8 @@ The MP 40 was designed by Heinrich Vollmer, taking inspiration from the MP 38. I
 
 The MP40 is an extremely common drop from [Regular Crates](/obstacles/regular_crate) as well as [Flint](/obstacles/flint_crate)/[AEGIS Crates](/obstacles/aegis_crate) and is overall one of the most easily obtainable guns in the game.
 
+<Obtaining item="mp40" />
+
 # Trivia
 
 - Prior to v0.9.0, the MP40 had a 30-round magazine

--- a/app/(wiki)/weapons/guns/articles/radio.md
+++ b/app/(wiki)/weapons/guns/articles/radio.md
@@ -15,6 +15,8 @@ Radios are a type of communication device that utilizes electromagnetic radio wa
 
 - Radios can be found rarely from common loot sources.
 
+<Obtaining item="radio" />
+
 ## Trivia
 
 - The radio uses the same sound effects as the [Deathray](/weapons/guns/deathray) except for the firing sound

--- a/app/(wiki)/weapons/guns/articles/s_g17.md
+++ b/app/(wiki)/weapons/guns/articles/s_g17.md
@@ -32,6 +32,8 @@ The G17 has currently been obtainable in only two events.
 - On the Halloween 2023 map, it had a 95% chance to drop from a Pumpkin.
 - The G17 was also rarely acquired during the Suroi Weapon Swap Event upon killing another player with any gun.
 
+<Obtaining item="s_g17" />
+
 # Trivia
 
 - Despite having infinite ammo, the G17 uses the "6mm BB" ammo type. This confirms that the G17 is an airsoft gun shooting orange airsoft BBs

--- a/app/(wiki)/weapons/guns/articles/saf_200.md
+++ b/app/(wiki)/weapons/guns/articles/saf_200.md
@@ -29,6 +29,8 @@ The original SAF was a modified version of the SIG SG 540 assault rifle, which w
 
 The SAF-200 is a very common gun, and can be found from [Regular Crates](/obstacles/regular_crate), as ground loot, and readily found from [AEGIS](/obstacles/aegis_crate) and [Flint Crates](/obstacles/flint_crate).
 
+<Obtaining item="saf_200" />
+
 # Trivia
 
 - The SAF-200 was the first SMG to be added to Suroi

--- a/app/(wiki)/weapons/guns/articles/sr25.md
+++ b/app/(wiki)/weapons/guns/articles/sr25.md
@@ -25,6 +25,8 @@ The SR-25 was designed by Eugene Stoner in the early 1990s for the Knight's Arma
 
 The SR-25 is found in many of the same drops as the [Mini-14](/weapons/guns/mini14). These include [AEGIS](/obstacles/aegis_crate) and [Flint Crates](/obstacles/flint_crate), [Airdrops](/obstacles/airdrop_crate), as well as other rare locations. It can also be rarely found as ground loot.
 
+<Obtaining item="sr25" />
+
 # Trivia
 
 - The loot image for the SR-25 is based specifically on a SR-25 E2 PR M-LOK

--- a/app/(wiki)/weapons/guns/articles/stoner_63.md
+++ b/app/(wiki)/weapons/guns/articles/stoner_63.md
@@ -29,6 +29,8 @@ The Stoner 63 was developed by Eugene Stoner after he left ArmaLite in 1961. Sto
 
 The Stoner 63 is rarely found in [Flint](/obstacles/flint_crate) and [AEGIS Crates](/obstacles/aegis_crate) and uncommonly in [Airdrops](/obstacles/airdrop_crate). It can also be found extremely rarely as world loot. The Stoner 63 also has a 1% chance to spawn in the [Refinery](/buildings/refinery) in place of the [MCX Spear](/weapons/guns/mcx_spear).
 
+<Obtaining item="stoner_63" />
+
 # Trivia
 
 - The Stoner 63 is the second LMG added to the game, after the [Lewis Gun](/weapons/guns/lewis_gun)

--- a/app/(wiki)/weapons/guns/articles/tango_51.md
+++ b/app/(wiki)/weapons/guns/articles/tango_51.md
@@ -23,6 +23,8 @@ The Tango 51 is a tactical sniper rifle designed and manufactured by Tactical Op
 
 The most reliable way to get a Tango 51 is to head for the [Ship](/buildings/ship) at the [Port](/buildings/port) at the beginning of the game, and solve the puzzle. The Tango 51 can also be found extremely rarely from common sources of loot such as [Regular Crates](/obstacles/regular_crate).
 
+<Obtaining item="tango_51" />
+
 # Trivia
 
 - The real-life Tango 51 is actually based on the action of a Remington 700.

--- a/app/(wiki)/weapons/guns/articles/usas12.md
+++ b/app/(wiki)/weapons/guns/articles/usas12.md
@@ -31,6 +31,8 @@ The USAS-12 has currently been obtainable in only two events.
 - On the Halloween 2023 map, it had a 5% chance to drop from a [Pumpkins](/obstacles/pumpkin).
 - The USAS-12 was also rarely acquired during the Suroi Weapon Swap Event upon killing another player with any gun.
 
+<Obtaining item="usas12" />
+
 # Trivia
 
 - USAS-12 stands for "Universal Sporting Automatic Shotgun 12 gauge"

--- a/app/(wiki)/weapons/guns/articles/vector.md
+++ b/app/(wiki)/weapons/guns/articles/vector.md
@@ -29,6 +29,8 @@ Then known as Transformational Defense Industries, the Vector was designed by KR
 # Obtaining
 The Vector can be found very rarely as world loot. However, the easiest way to acquire a Vector is to find one from a [Briefcase](/obstacles/briefcase) at either the Oil Tanker or the Armory. It can also be found the in the [Viking Chest](/obstacles/viking_chest).
 
+<Obtaining item="vector" />
+
 # Trivia
 - The Vector is one of 6 guns that were in surviv.io, the others being the [M1 Garand](/weapons/guns/m1_garand), [VSS](/weapons/guns/vss), [USAS-12](/weapons/guns/usas12), [AK-47](/weapons/guns/ak47), and [Mosin-Nagant](/weapons/guns/mosin)
 - The in-game Vector is the first and so far only gun that is colored white

--- a/app/(wiki)/weapons/guns/articles/vepr12.md
+++ b/app/(wiki)/weapons/guns/articles/vepr12.md
@@ -26,6 +26,8 @@ The Vepr-12 was originally designed by the Kalashnikov Group (then Izhmash) in t
 # Obtaining
 The Vepr-12 can be found rarely as world loot. It is more common in higher-tier loot sources such as [Viking Chests](/obstacles/viking_chest), [Briefcases](/obstacles/briefcase), and others.
 
+<Obtaining item="vepr12" />
+
 # Trivia
 - In real life, the Vepr-12 is a direct competitor to the Saiga-12, which was in surviv.io
 - This is the second automatic shotgun to be added to Suroi, after the [USAS-12](/weapons/guns/usas12).

--- a/app/(wiki)/weapons/guns/articles/vss.md
+++ b/app/(wiki)/weapons/guns/articles/vss.md
@@ -29,6 +29,8 @@ The VSS was developed beginning in 1983 by TsNIITochMash, a then-Soviet industri
 
 The VSS is most easily found in special loot such as [AEGIS](/obstacles/aegis_crate) and [Flint Crates](/obstacles/flint_crate). It can also be rarely found from [Regular Crates](/obstacles/regular_crate) or as ground loot.
 
+<Obtaining item="vss" />
+
 # Trivia
 
 - The VSS is one of 6 guns that were in surviv.io, the others being the [AK-47](/weapons/guns/ak47), [M1 Garand](/weapons/guns/m1_garand), [USAS-12](/weapons/guns/usas12), and [Mosin-Nagant](/weapons/guns/mosin)

--- a/app/(wiki)/weapons/melee/articles/baseball_bat.md
+++ b/app/(wiki)/weapons/melee/articles/baseball_bat.md
@@ -21,6 +21,8 @@ The Baseball Bat is a smooth wooden or metal club used in the sport of baseball 
 
 Baseball Bats have a high chance of spawning from the [Melee Crate](/obstacles/melee_crate). They can also be found rarely from [Regular Crates](/obstacles/regular_crate).
 
+<Obtaining item="baseball_bat" />
+
 # Trivia
 
 - The Baseball Bat was designed by Radians

--- a/app/(wiki)/weapons/melee/articles/gas_can.md
+++ b/app/(wiki)/weapons/melee/articles/gas_can.md
@@ -19,6 +19,8 @@ The only way to obtain the Gas Can in normal mode is to head to the ship in the 
 
 - In the Suroi Weapon Swap Event, it could be acquired from swapping after getting a melee kill. This was the only time more than one Gas Can at a time was in a game.
 
+<Obtaining item="gas_can" />
+
 # Trivia
 
 - The Gas was designed by 1092384

--- a/app/(wiki)/weapons/melee/articles/kbar.md
+++ b/app/(wiki)/weapons/melee/articles/kbar.md
@@ -19,7 +19,9 @@ The K-Bar is a combat knife designed by Union Cutlery, John M. Davis, and Howard
 
 # Obtaining
 
-The K-Bar can be obtained rarely from crates or other common loot sources. Additionally, it has a 75% chance of spawning in the melee crate that spawns once per map.
+The K-Bar can be obtained rarely from crates or other common loot sources.
+
+<Obtaining item="kbar" />
 
 # Trivia
 

--- a/app/(wiki)/weapons/melee/articles/maul.md
+++ b/app/(wiki)/weapons/melee/articles/maul.md
@@ -23,6 +23,8 @@ The maul is a long-handled hammer with a heavy head of wood, lead, iron, or stee
 
 The Maul can only be obtained from the [Maul Mount](/obstacles/gun_mounts) in the [Armory Center](/buildings/armory_meta).
 
+<Obtaining item="maul" />
+
 # Trivia
 
 - The Maul was designed by Radians

--- a/app/(wiki)/weapons/melee/articles/seax.md
+++ b/app/(wiki)/weapons/melee/articles/seax.md
@@ -20,6 +20,8 @@ The Seax is a large single-edged blade with a tang in the centerline of the blad
 
 The Seax can only be obtained from the [Viking Chest](/obstacles/viking_chest), which always spawns once per game and is located along the shore in the map. 
 
+<Obtaining item="seax" />
+
 # Trivia
 
 - The Seax was designed by cobby and 1092384

--- a/app/(wiki)/weapons/throwables/articles/frag_grenade.md
+++ b/app/(wiki)/weapons/throwables/articles/frag_grenade.md
@@ -41,6 +41,8 @@ This is a special technique that abuses the behavior of frag grenades pushing ot
 # Obtaining
 Frag Grenades can sometimes be obtained from [Regular Crates](/obstacles/regular_crate), but are much more often dropped from [Grenade Crates](/obstacles/grenade_crate).
 
+<Obtaining item="frag_grenade" />
+
 # Trivia
 - The Frag Grenade is based on the real-life M67 grenade used by the U.S. military
 

--- a/app/(wiki)/weapons/throwables/articles/smoke_grenade.md
+++ b/app/(wiki)/weapons/throwables/articles/smoke_grenade.md
@@ -15,6 +15,10 @@ The **Smoke Grenade** is a [Throwable](/throwables) added in the v0.15.0 "Pullin
 - If the enemy is using the smoke grenade offensively, you can also hide in the smoke when it is safe to do so
   - Avoid this if the enemy has powerful close-range weapons like shotguns and the [Micro Uzi](/weapons/guns/micro_uzi)
 
+# Obtaining
+
+<Obtaining item="smoke_grenade" />
+
 <Gallery
   images={[
     {

--- a/app/api/loot/locations/route.ts
+++ b/app/api/loot/locations/route.ts
@@ -15,7 +15,10 @@ const LootTierItemChances: Record<string, ChanceCollection> = {};
 // let's assume all loot tier chains does not form a loop
 // or the game may enter an infinite loop when generating loots
 // which breaks both the game and this function
-function registerItemChances(tier: string, items: WeightedItem[]): ChanceCollection {
+function registerItemChances(
+  tier: string,
+  items: WeightedItem[],
+): ChanceCollection {
   if (tier in LootTierItemChances) return LootTierItemChances[tier];
 
   const result: ChanceCollection = {};
@@ -26,13 +29,16 @@ function registerItemChances(tier: string, items: WeightedItem[]): ChanceCollect
     else result[item] = chance;
   }
 
-  items.forEach(item => {
-    if ('item' in item && item.item != null) {
+  items.forEach((item) => {
+    if ("item" in item && item.item != null) {
       addEntry(item.item, item.weight / totalWeight);
     }
-    if ('tier' in item) {
+    if ("tier" in item) {
       const factor = item.weight / totalWeight;
-      const subTierChances = registerItemChances(item.tier, LootTiers[item.tier]);
+      const subTierChances = registerItemChances(
+        item.tier,
+        LootTiers[item.tier],
+      );
       for (const it in subTierChances) {
         addEntry(it, subTierChances[it] * factor);
       }
@@ -56,17 +62,18 @@ function calcChance(table: LootTable, item: string): number {
   let singleRollChance = 0;
 
   const lootPacks = is2dArray(table.loot) ? table.loot : [table.loot];
-  lootPacks.forEach(pack => {
+  lootPacks.forEach((pack) => {
     const totalWeight = pack.reduce((acc, cur) => acc + cur.weight, 0);
 
-    pack.forEach(loot => {
+    pack.forEach((loot) => {
       const chance = loot.weight / totalWeight;
       let singlePackChance = 0;
-      if ('item' in loot && loot.item == item) {
+      if ("item" in loot && loot.item == item) {
         singlePackChance += chance;
       }
-      if ('tier' in loot) {
-        singlePackChance += (LootTierItemChances[loot.tier][item] ?? 0) * chance;
+      if ("tier" in loot) {
+        singlePackChance +=
+          (LootTierItemChances[loot.tier][item] ?? 0) * chance;
       }
 
       singleRollChance = 1 - (1 - singleRollChance) * (1 - singlePackChance);
@@ -79,7 +86,7 @@ function calcChance(table: LootTable, item: string): number {
   let chance = 0;
   for (let i = table.min; i <= table.max; i++) {
     chance += 1 - acc;
-    acc *= (1 - singleRollChance);
+    acc *= 1 - singleRollChance;
   }
 
   return chance / (table.max - table.min + 1);
@@ -109,9 +116,11 @@ export async function GET(req: NextRequest) {
   return new NextResponse(JSON.stringify(result));
 }
 
-export type LootLocationsResponse = {
-  tableName: string;
-  chance: number;
-}[] | {
-  error: APIErrorCodes
-};
+export type LootLocationsResponse =
+  | {
+      tableName: string;
+      chance: number;
+    }[]
+  | {
+      error: APIErrorCodes;
+    };

--- a/app/api/loot/locations/route.ts
+++ b/app/api/loot/locations/route.ts
@@ -1,0 +1,117 @@
+import APIErrorCodes from "@/lib/api/ErrorCodes";
+import { Loots } from "@/vendor/suroi/common/src/definitions/loots";
+import {
+  LootTable,
+  LootTables,
+  LootTiers,
+  WeightedItem,
+} from "@/vendor/suroi/server/src/data/lootTables";
+import { NextRequest, NextResponse } from "next/server";
+
+type ChanceCollection = Record<string, number>;
+
+const LootTierItemChances: Record<string, ChanceCollection> = {};
+
+// let's assume all loot tier chains does not form a loop
+// or the game may enter an infinite loop when generating loots
+// which breaks both the game and this function
+function registerItemChances(tier: string, items: WeightedItem[]): ChanceCollection {
+  if (tier in LootTierItemChances) return LootTierItemChances[tier];
+
+  const result: ChanceCollection = {};
+  const totalWeight = items.reduce((acc, cur) => acc + cur.weight, 0);
+
+  function addEntry(item: string, chance: number) {
+    if (item in result) result[item] += chance;
+    else result[item] = chance;
+  }
+
+  items.forEach(item => {
+    if ('item' in item && item.item != null) {
+      addEntry(item.item, item.weight / totalWeight);
+    }
+    if ('tier' in item) {
+      const factor = item.weight / totalWeight;
+      const subTierChances = registerItemChances(item.tier, LootTiers[item.tier]);
+      for (const it in subTierChances) {
+        addEntry(it, subTierChances[it] * factor);
+      }
+    }
+  });
+
+  LootTierItemChances[tier] = result;
+  return LootTierItemChances[tier];
+}
+
+for (const tier in LootTiers) {
+  registerItemChances(tier, LootTiers[tier]);
+}
+
+// type guard
+function is2dArray<T>(a: T[] | T[][]): a is T[][] {
+  return Array.isArray(a[0]);
+}
+
+function calcChance(table: LootTable, item: string): number {
+  let singleRollChance = 0;
+
+  const lootPacks = is2dArray(table.loot) ? table.loot : [table.loot];
+  lootPacks.forEach(pack => {
+    const totalWeight = pack.reduce((acc, cur) => acc + cur.weight, 0);
+
+    pack.forEach(loot => {
+      const chance = loot.weight / totalWeight;
+      let singlePackChance = 0;
+      if ('item' in loot && loot.item == item) {
+        singlePackChance += chance;
+      }
+      if ('tier' in loot) {
+        singlePackChance += (LootTierItemChances[loot.tier][item] ?? 0) * chance;
+      }
+
+      singleRollChance = 1 - (1 - singleRollChance) * (1 - singlePackChance);
+    });
+  });
+
+  if (singleRollChance == 0) return 0;
+
+  let acc = (1 - singleRollChance) ** table.min;
+  let chance = 0;
+  for (let i = table.min; i <= table.max; i++) {
+    chance += 1 - acc;
+    acc *= (1 - singleRollChance);
+  }
+
+  return chance / (table.max - table.min + 1);
+}
+
+export async function GET(req: NextRequest) {
+  const itemSearch = req.nextUrl.searchParams.get("item");
+  if (!itemSearch) return new NextResponse(null, { status: 400 });
+
+  const item = Loots.definitions.find((loot) => loot.idString === itemSearch);
+  if (!item)
+    return new NextResponse(
+      JSON.stringify({
+        error: APIErrorCodes.ItemNotFound,
+      }),
+      { status: 404 },
+    );
+
+  const result: LootLocationsResponse = [];
+  for (const tableName in LootTables) {
+    const chance = calcChance(LootTables[tableName], itemSearch);
+    if (chance == 0) continue;
+    result.push({ tableName, chance });
+  }
+  result.sort(({ chance: a }, { chance: b }) => b - a);
+
+  return new NextResponse(JSON.stringify(result));
+}
+
+export type LootLocationsResponse = {
+  tableName: string;
+  chance: number;
+}[] | {
+  error: APIErrorCodes
+};

--- a/components/articles/Obtaining.tsx
+++ b/components/articles/Obtaining.tsx
@@ -6,6 +6,18 @@ import TableWithHeader from "../tables/TableWithHeader";
 import { LootLocationsResponse } from "@/app/api/loot/locations/route";
 import { Obstacles } from "@/vendor/suroi/common/src/definitions/obstacles";
 
+function getChanceString(chance: number): string {
+  if (chance == 1) return '100%';
+  if (chance == 0) return '0%';
+
+  let prec = 2;
+  for (let d = 0.1 ** (prec+1); prec < 15; d *= 0.1, prec++) {
+    if (d <= chance && chance < 1 - d) break;
+  }
+
+  return (chance * 100).toFixed(prec) + '%';
+}
+
 export default function Obtaining(props: ObtainingProps) {
   const results = useQuery<LootLocationsResponse>({
     queryKey: ["loottablelocations", props],
@@ -18,7 +30,7 @@ export default function Obtaining(props: ObtainingProps) {
   if (results.isPending) return 'Loading...';
   if (results.error) return `Error: ${results.error.message}`;
   if ('error' in results.data) return `Error: ${ErrorMessages[results.data.error]}`;
-  if (!results.data.length) return `This item cannot be found in any location.`;
+  if (!results.data.length) return 'This item cannot be found in any location.';
 
   return (
     <div className="mb-8">
@@ -26,7 +38,7 @@ export default function Obtaining(props: ObtainingProps) {
         key={props.item}
         header={["Location", "% Chance"]}
         content={results.data.map(({ tableName, chance }) => {
-          const chanceString = (chance * 100).toFixed(2) + '%';
+          const chanceString = getChanceString(chance);
           const name = Obstacles.definitions.find(obs => obs.idString == tableName)?.name;
           return [name ? <Link href={`/obstacles/${tableName}`}>{name}</Link> : tableName, chanceString];
         })}

--- a/components/articles/Obtaining.tsx
+++ b/components/articles/Obtaining.tsx
@@ -25,34 +25,41 @@ export default function Obtaining(props: ObtainingProps) {
       fetch(`/api/loot/locations?item=${props.item}`).then((r) => r.json()),
   });
 
-  if (results.isPending) return "Loading...";
-  if (results.error) return `Error: ${results.error.message}`;
-  if ("error" in results.data)
-    return `Error: ${ErrorMessages[results.data.error]}`;
-  if (!results.data.length) return "This item cannot be found in any location.";
+  let info = "";
+  if (results.isPending) {
+    info = "Loading Template...";
+  } else if (results.error) {
+    info = `Error: ${results.error.message}`;
+  } else if ("error" in results.data) {
+    info = `Error: ${ErrorMessages[results.data.error]}`;
+  } else if (!results.data.length) {
+    info = "This item cannot be found in any location.";
+  } else {
+    return (
+      <div className="mb-8">
+        <TableWithHeader
+          key={props.item}
+          header={["Location", "% Chance"]}
+          content={results.data.map(({ tableName, chance }) => {
+            const chanceString = getChanceString(chance);
+            const name = Obstacles.definitions.find(
+              (obs) => obs.idString == tableName,
+            )?.name;
+            return [
+              name ? (
+                <Link href={`/obstacles/${tableName}`}>{name}</Link>
+              ) : (
+                tableName
+              ),
+              chanceString,
+            ];
+          })}
+        />
+      </div>
+    );
+  }
 
-  return (
-    <div className="mb-8">
-      <TableWithHeader
-        key={props.item}
-        header={["Location", "% Chance"]}
-        content={results.data.map(({ tableName, chance }) => {
-          const chanceString = getChanceString(chance);
-          const name = Obstacles.definitions.find(
-            (obs) => obs.idString == tableName,
-          )?.name;
-          return [
-            name ? (
-              <Link href={`/obstacles/${tableName}`}>{name}</Link>
-            ) : (
-              tableName
-            ),
-            chanceString,
-          ];
-        })}
-      />
-    </div>
-  );
+  return <div className="mb-8">{info}</div>;
 }
 
 export interface ObtainingProps extends React.PropsWithChildren {

--- a/components/articles/Obtaining.tsx
+++ b/components/articles/Obtaining.tsx
@@ -1,46 +1,54 @@
 "use client";
+import { LootLocationsResponse } from "@/app/api/loot/locations/route";
 import Link from "@/components/links/Link";
 import { ErrorMessages } from "@/lib/api/ErrorCodes";
+import { Obstacles } from "@/vendor/suroi/common/src/definitions/obstacles";
 import { useQuery } from "@tanstack/react-query";
 import TableWithHeader from "../tables/TableWithHeader";
-import { LootLocationsResponse } from "@/app/api/loot/locations/route";
-import { Obstacles } from "@/vendor/suroi/common/src/definitions/obstacles";
 
 function getChanceString(chance: number): string {
-  if (chance == 1) return '100%';
-  if (chance == 0) return '0%';
+  if (chance == 1) return "100%";
+  if (chance == 0) return "0%";
 
   let prec = 2;
-  for (let d = 0.1 ** (prec+1); prec < 15; d *= 0.1, prec++) {
+  for (let d = 0.1 ** (prec + 1); prec < 15; d *= 0.1, prec++) {
     if (d <= chance && chance < 1 - d) break;
   }
 
-  return (chance * 100).toFixed(prec) + '%';
+  return (chance * 100).toFixed(prec) + "%";
 }
 
 export default function Obtaining(props: ObtainingProps) {
   const results = useQuery<LootLocationsResponse>({
     queryKey: ["loottablelocations", props],
     queryFn: () =>
-      fetch(
-        `/api/loot/locations?item=${props.item}`,
-      ).then(r => r.json()),
+      fetch(`/api/loot/locations?item=${props.item}`).then((r) => r.json()),
   });
 
-  if (results.isPending) return 'Loading...';
+  if (results.isPending) return "Loading...";
   if (results.error) return `Error: ${results.error.message}`;
-  if ('error' in results.data) return `Error: ${ErrorMessages[results.data.error]}`;
-  if (!results.data.length) return 'This item cannot be found in any location.';
+  if ("error" in results.data)
+    return `Error: ${ErrorMessages[results.data.error]}`;
+  if (!results.data.length) return "This item cannot be found in any location.";
 
   return (
     <div className="mb-8">
-      <TableWithHeader 
+      <TableWithHeader
         key={props.item}
         header={["Location", "% Chance"]}
         content={results.data.map(({ tableName, chance }) => {
           const chanceString = getChanceString(chance);
-          const name = Obstacles.definitions.find(obs => obs.idString == tableName)?.name;
-          return [name ? <Link href={`/obstacles/${tableName}`}>{name}</Link> : tableName, chanceString];
+          const name = Obstacles.definitions.find(
+            (obs) => obs.idString == tableName,
+          )?.name;
+          return [
+            name ? (
+              <Link href={`/obstacles/${tableName}`}>{name}</Link>
+            ) : (
+              tableName
+            ),
+            chanceString,
+          ];
         })}
       />
     </div>

--- a/components/articles/Obtaining.tsx
+++ b/components/articles/Obtaining.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Link from "@/components/links/Link";
+import { ErrorMessages } from "@/lib/api/ErrorCodes";
+import { useQuery } from "@tanstack/react-query";
+import TableWithHeader from "../tables/TableWithHeader";
+import { LootLocationsResponse } from "@/app/api/loot/locations/route";
+import { Obstacles } from "@/vendor/suroi/common/src/definitions/obstacles";
+
+export default function Obtaining(props: ObtainingProps) {
+  const results = useQuery<LootLocationsResponse>({
+    queryKey: ["loottablelocations", props],
+    queryFn: () =>
+      fetch(
+        `/api/loot/locations?item=${props.item}`,
+      ).then(r => r.json()),
+  });
+
+  if (results.isPending) return 'Loading...';
+  if (results.error) return `Error: ${results.error.message}`;
+  if ('error' in results.data) return `Error: ${ErrorMessages[results.data.error]}`;
+  if (!results.data.length) return `This item cannot be found in any location.`;
+
+  return (
+    <div className="mb-8">
+      <TableWithHeader 
+        key={props.item}
+        header={["Location", "% Chance"]}
+        content={results.data.map(({ tableName, chance }) => {
+          const chanceString = (chance * 100).toFixed(2) + '%';
+          const name = Obstacles.definitions.find(obs => obs.idString == tableName)?.name;
+          return [name ? <Link href={`/obstacles/${tableName}`}>{name}</Link> : tableName, chanceString];
+        })}
+      />
+    </div>
+  );
+}
+
+export interface ObtainingProps extends React.PropsWithChildren {
+  item: string;
+}

--- a/components/client/MDXClient.tsx
+++ b/components/client/MDXClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "@/components/links/Link";
+import Obtaining from "@/components/articles/Obtaining";
 import { MDXRemote, MDXRemoteProps } from "next-mdx-remote";
 import { HTMLProps } from "react";
 import Spoiler from "../articles/Spoiler";
@@ -16,6 +17,7 @@ import TimeLink from "../links/TimeLink";
 
 const components = {
   Link,
+  Obtaining,
   Event: EventItem,
   TimeLink,
   FileLink,


### PR DESCRIPTION
- Added a table of drop rates for every item, as the following image shows
- Because some crates may drop multiple loots, some items may have their calculated drop rates higher than the loot table

![image](https://github.com/HasangerGames/suroi-wiki/assets/81338417/e2a78605-7a30-4075-9491-f37f926fd966)
