### PR TITLE
you forgot THREE slashes

### DIFF
--- a/app/(wiki)/weapons/guns/articles/mini14.md
+++ b/app/(wiki)/weapons/guns/articles/mini14.md
@@ -9,8 +9,8 @@ The Mini-14, as the name suggests, is based on the bigger 7.62x51mm NATO firing 
 ## Using
 
 - The Mini-14 is best used at long-range, but its high DPS makes it effective against many weapons at mid-range as well.
-- Stay at long range, as the high accuracy and fast bullet speed make the Mini-14 very powerful against other long-range weapons like snipers and the [MCX Spear.](weapons/guns/mcx_spear)
-- The [SR-25](weapons/guns/sr25) has more damage than the Mini-14 albeit at the cost of a slightly lower DPS.
+- Stay at long range, as the high accuracy and fast bullet speed make the Mini-14 very powerful against other long-range weapons like snipers and the [MCX Spear.](/weapons/guns/mcx_spear)
+- The [SR-25](/weapons/guns/sr25) has more damage than the Mini-14 albeit at the cost of a slightly lower DPS.
 - Pair the Mini-14 with a high-DPS shotgun or SMG for close-range combat.
 
 ## Countering
@@ -21,7 +21,7 @@ The Mini-14, as the name suggests, is based on the bigger 7.62x51mm NATO firing 
   - Hide around indestructible obstacles such as [Oil Tanks](/obstacles/oil_tank) or in [Buildings](/buildings) to force the Mini-14 user into close-range combat.
   - Be careful, however, as they might have a shotgun or SMG of their own as a secondary weapon.
 - At long-range, snipers can be effective against the Mini-14, provided that you quickswitch to move around quicker.
-- The [MCX Spear](weapons/guns/mcx_spear) has a higher DPS and comparable accuracy to the Mini-14, and can be used as a counter.
+- The [MCX Spear](/weapons/guns/mcx_spear) has a higher DPS and comparable accuracy to the Mini-14, and can be used as a counter.
 
 # Obtaining
 


### PR DESCRIPTION
on every weapon link in the mini-14 article, you put (weapons/guns/weaponname) instead of (/weapons/guns/weaponname), which made the link go to wiki.suroi.io/weapons/guns/weapons/guns/weaponname